### PR TITLE
Update blimp.sh

### DIFF
--- a/blimp.sh
+++ b/blimp.sh
@@ -88,16 +88,15 @@ ${BLIMP_DOMAIN} {
 		uri strip_prefix /minioclient
 		reverse_proxy minioclient:3001
 	}
-
-	route /s3server* {
-		uri strip_prefix /s3server
-		reverse_proxy minioserver:9000
-	}
-
+ 
 	route /logsearch/* {
 		uri strip_prefix /logsearch
 		reverse_proxy api:8080
 	}
+ 
+ 	route {
+  		reverse_proxy minioserver:9000
+  	}
 }
 EOF
 


### PR DESCRIPTION
Fixing the zs3server end points not working with aws cli issue. 

We needed to expose s3server endpoints as pure URLs instead of url ending with resources. Check https://github.com/0chain/zs3server/issues/78 for more info.