### PR TITLE
Fix/loki permission issue

### DIFF
--- a/0chain/grafana-portainer/docker-compose.yaml
+++ b/0chain/grafana-portainer/docker-compose.yaml
@@ -42,7 +42,7 @@ services:
     volumes:
       - ./loki/loki-config.yaml:/mnt/config/loki-config.yaml
       - ./loki:/data
-      - ./loki/rules:/tmp/loki/rules
+      - ./loki/rules:/etc/loki/rules
     command: -config.file=/mnt/config/loki-config.yaml
     # ports:
     #   - "3100:3100"

--- a/0chain/grafana-portainer/loki/loki-config.yaml
+++ b/0chain/grafana-portainer/loki/loki-config.yaml
@@ -80,8 +80,8 @@ ruler:
   storage:
     type: local
     local:
-      directory: /tmp/loki/rules
-  rule_path: /tmp/loki/rules-temp
+      directory: /etc/loki/rules
+  rule_path: /etc/loki/rules-temp
   alertmanager_url: http://localhost:9093
   ring:
     kvstore:

--- a/blobber-files/monitoringconfig/loki-config.yaml
+++ b/blobber-files/monitoringconfig/loki-config.yaml
@@ -41,15 +41,15 @@ schema_config:
 
 storage_config:
   boltdb_shipper:
-    active_index_directory: /tmp/loki/boltdb-shipper-active
-    cache_location: /tmp/loki/boltdb-shipper-cache
+    active_index_directory: /etc/loki/boltdb-shipper-active
+    cache_location: /etc/loki/boltdb-shipper-cache
     cache_ttl: 24h         # Can be increased for faster performance over longer query periods, uses more disk space
     shared_store: filesystem
   filesystem:
-    directory: /tmp/loki/chunks
+    directory: /etc/loki/chunks
 
 compactor:
-  working_directory: /tmp/loki/boltdb-shipper-compactor
+  working_directory: /etc/loki/boltdb-shipper-compactor
   shared_store: filesystem
 
 limits_config:
@@ -70,8 +70,8 @@ ruler:
   storage:
     type: local
     local:
-      directory: /tmp/loki/rules
-  rule_path: /tmp/loki/rules-temp
+      directory: /etc/loki/rules
+  rule_path: /etc/loki/rules-temp
   alertmanager_url: http://localhost:9093
   ring:
     kvstore:

--- a/chimney.sh
+++ b/chimney.sh
@@ -231,8 +231,8 @@ ${BLOBBER_HOST} {
   }
 }
 
-
 EOF
+
 ### docker-compose.yaml
 echo "creating docker-compose file"
 cat <<EOF >${PROJECT_ROOT}/docker-compose.yml
@@ -324,7 +324,6 @@ services:
     volumes:
       - ${PROJECT_ROOT}/monitoringconfig/loki-config.yaml:/mnt/config/loki-config.yaml
       - ${PROJECT_ROOT_HDD}/loki:/data
-      # 
       - ${PROJECT_ROOT_HDD}/loki/rules:/etc/loki/rules
     command: -config.file=/mnt/config/loki-config.yaml
     restart: "always"

--- a/chimney.sh
+++ b/chimney.sh
@@ -232,7 +232,7 @@ ${BLOBBER_HOST} {
 }
 
 EOF
-
+# aslkdfjaslfj
 ### docker-compose.yaml
 echo "creating docker-compose file"
 cat <<EOF >${PROJECT_ROOT}/docker-compose.yml
@@ -324,7 +324,8 @@ services:
     volumes:
       - ${PROJECT_ROOT}/monitoringconfig/loki-config.yaml:/mnt/config/loki-config.yaml
       - ${PROJECT_ROOT_HDD}/loki:/data
-      - ${PROJECT_ROOT_HDD}/loki/rules:/tmp/loki/rules
+      # 
+      - ${PROJECT_ROOT_HDD}/loki/rules:/etc/loki/rules
     command: -config.file=/mnt/config/loki-config.yaml
     restart: "always"
 

--- a/chimney.sh
+++ b/chimney.sh
@@ -232,7 +232,6 @@ ${BLOBBER_HOST} {
 }
 
 EOF
-# aslkdfjaslfj
 ### docker-compose.yaml
 echo "creating docker-compose file"
 cat <<EOF >${PROJECT_ROOT}/docker-compose.yml

--- a/chimney.sh
+++ b/chimney.sh
@@ -231,6 +231,7 @@ ${BLOBBER_HOST} {
   }
 }
 
+
 EOF
 ### docker-compose.yaml
 echo "creating docker-compose file"


### PR DESCRIPTION
There is a problem that /tmp/loki can't be used as volumes. Read https://github.com/grafana/loki/issues/1833. In this diff, we remove the /tmp/loki and used /etc/loki instead. 

Verified the change by re-deploying chimney using the script generated and replacing the curl URL to https://raw.githubusercontent.com/0chain/zcnwebappscripts/fix/loki-permission-issue/chimney.sh and 
`docker ps` in the server shows grafana/loki running
<img width="1320" alt="Screenshot 2023-11-25 at 12 24 43 AM" src="https://github.com/0chain/zcnwebappscripts/assets/56060325/f0d93c3b-7710-45dd-b6cb-9ed2ee59f804">
