### PR TITLE
update delegate wallet for validator

### DIFF
--- a/chimney.sh
+++ b/chimney.sh
@@ -183,6 +183,9 @@ sed -i "s/service_charge.*/service_charge: ${SERVICE_CHARGE}/g" ${PROJECT_ROOT}/
 echo "updating block_worker"
 sed -i "s|block_worker.*|block_worker: ${BLOCK_WORKER_URL}|g" ${PROJECT_ROOT}/config/0chain_validator.yaml
 
+echo "updating delegate_wallet"
+sed -i "s/delegate_wallet.*/delegate_wallet: ${DELEGATE_WALLET}/g" ${PROJECT_ROOT}/config/0chain_validator.yaml
+
 ### Create minio_config.txt file
 echo "creating minio_config.txt"
 cat <<EOF >${PROJECT_ROOT}/keys_config/minio_config.txt


### PR DESCRIPTION
tested the change on dev network. 

With this change able to shutdown both blobber and validator with the delegate wallet